### PR TITLE
Revert "Let's try ruby 3.4"

### DIFF
--- a/.github/workflows/.yamllint
+++ b/.github/workflows/.yamllint
@@ -3,6 +3,5 @@ extends: default
 
 rules:
   line-length: disable
-  document-start: disable
   truthy:
     check-keys: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,6 +91,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.docker-platform }}
-          provenance: false  # Bug: https://github.com/docker/build-push-action/issues/820
+          provenance: false # Bug: https://github.com/docker/build-push-action/issues/820
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          

--- a/.github/workflows/jekyll-link-checker.yml
+++ b/.github/workflows/jekyll-link-checker.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: 3.3
           bundler-cache: true
 
       - name: Do not render with liquid


### PR DESCRIPTION
Reverts vespa-engine/gh-actions#17

I see things like

````
google-protobuf-3.25.5-x86_64-linux requires ruby version < 3.4.dev, >= 2.7,
````
