### PR TITLE
fix: update push command in sync-codeowners workflow

### DIFF
--- a/.github/workflows/sync-codeowners.yml
+++ b/.github/workflows/sync-codeowners.yml
@@ -59,4 +59,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/CODEOWNERS
           git commit -m "Update CODEOWNERS file"
-          git push
+          git push origin HEAD:${GITHUB_REF_NAME}


### PR DESCRIPTION
Change the push command in the sync-codeowners workflow to specify the  
remote branch explicitly. This ensures that changes are pushed to the  
correct branch during the workflow execution.