### PR TITLE
Revert "less concurrency"

### DIFF
--- a/.github/workflows/jekyll-link-checker.yml
+++ b/.github/workflows/jekyll-link-checker.yml
@@ -139,6 +139,6 @@ jobs:
             --no-check-external-hash \
             --no-enforce-https \
             --swap-urls "${SWAP_URLS}" \
-            --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate", "max_concurrency": 1}' \
+            --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate"}' \
             ${{ inputs.additional-args }} \
             _site


### PR DESCRIPTION
Reverts vespa-engine/gh-actions#24

```
/home/runner/work/sample-apps/sample-apps/vendor/bundle/ruby/3.3.0/gems/ethon-0.16.0/lib/ethon/easy.rb:238:in `block in set_attributes': The option: max_concurrency is invalid. (Ethon::Errors::InvalidOption)
```